### PR TITLE
Display business hours

### DIFF
--- a/components/Footer/footer.module.scss
+++ b/components/Footer/footer.module.scss
@@ -27,7 +27,7 @@ div.row {
   &:nth-of-type(2) {
     grid-template-columns: repeat(auto-fit, min(200px));
     justify-content: center;
-    border-top: 1px solid #FFFFFF;
+    border-top: 1px solid #ffffff;
     padding: 0 0 15px 0;
   }
 }
@@ -58,13 +58,15 @@ div.map {
 // Contact Information Container
 div.information {
   padding: 0 40px;
-  color: #FFFFFF;
+  color: #ffffff;
+  width: auto;
   @media only screen and (max-width: $breakpoint) {
     order: 0;
     padding: 0 10px;
     text-align: center;
   }
-  h1, p {
+  h1,
+  p {
     margin: 0;
     padding: 0;
     line-height: 1.5em;
@@ -92,6 +94,9 @@ div.information {
       text-decoration: none;
     }
   }
+  .hours {
+    max-width: 300px;
+  }
   .headerText {
     padding-top: 12.5px;
   }
@@ -104,7 +109,7 @@ div.smContainer {
   padding: 20px 0 7.5px 0;
   position: absolute;
   top: 15%;
-  right: 35px;
+  right: 45px;
   background-color: vars.$muse-light-blue;
   @media only screen and (max-width: $breakpoint) {
     width: 265px;
@@ -126,13 +131,13 @@ div.smContainer {
     transition: 0.25s box-shadow;
     background-color: vars.$muse-orange;
     font-size: 1.5em;
-    color: #FFFFFF;
+    color: #ffffff;
     &:hover {
       cursor: pointer;
-      box-shadow: 0 0 7.5px 3px #FFFFFF;
+      box-shadow: 0 0 7.5px 3px #ffffff;
     }
     &:focus {
-      outline: 1px solid #FFFFFF;
+      outline: 1px solid #ffffff;
     }
     @media only screen and (max-width: $breakpoint) {
       margin: 0 5px 12.5px 5px;
@@ -150,7 +155,7 @@ div.links {
     font-size: 1.15em;
     font-weight: 900px;
     margin: 15px 0 10px 0;
-    color: #FFFFFF;
+    color: #ffffff;
   }
   a {
     color: vars.$muse-link;
@@ -161,7 +166,7 @@ div.links {
     }
     // Special styling for links that should stick out.
     span {
-      color: #EF4523;
+      color: #ef4523;
       font-weight: 700;
     }
   }

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -7,23 +7,26 @@ import {
   client,
 } from "server/actions/Contentful";
 import { compressDays } from "utils/helpers";
+import { BusinessHoursResponse } from "utils/types";
 
 const Footer: React.FC = () => {
   const mapSrc =
     "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d25758.679140926608!2d-83.94080239265877!3d35.985431235796526!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x885c16f484d1dbdb%3A0x1612d2810873bf5e!2sMuse%20Knoxville!5e0!3m2!1sen!2sus!4v1612997623235!5m2!1sen!2sus";
 
-  const { data: wd, loading: wdl, error: wde } = useQuery(
-    GET_WEEKDAY_BUSINESS_HOURS,
-    {
-      client: client,
-    }
-  );
-  const { data: we, loading: wel, error: wee } = useQuery(
-    GET_WEEKEND_BUSINESS_HOURS,
-    {
-      client: client,
-    }
-  );
+  const {
+    data: wd,
+    loading: wdl,
+    error: wde,
+  } = useQuery<BusinessHoursResponse>(GET_WEEKDAY_BUSINESS_HOURS, {
+    client: client,
+  });
+  const {
+    data: we,
+    loading: wel,
+    error: wee,
+  } = useQuery<BusinessHoursResponse>(GET_WEEKEND_BUSINESS_HOURS, {
+    client: client,
+  });
   return (
     <footer className={styles.container}>
       <div className={styles.row}>
@@ -52,13 +55,13 @@ const Footer: React.FC = () => {
             HOURS - <span>Admission must be booked online, in advance</span>
           </h1>
           <p>Special Programs Monday & Thursday</p>
-          {wd && !wdl && (
+          {wd && !wdl && !wde && (
             <p className={styles.hours}>
               {compressDays(wd.businessHoursCollection.items[0].daysOpen)}
               {wd.businessHoursCollection.items[0].hours.join(", ")}
             </p>
           )}
-          {we && !wel && (
+          {we && !wel && !wee && (
             <p className={styles.hours}>
               {compressDays(we.businessHoursCollection.items[0].daysOpen)}
               {we.businessHoursCollection.items[0].hours.join(", ")}

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,5 +1,7 @@
 import styles from "./footer.module.scss";
 import { FaFacebookF, FaInstagram, FaTwitter, FaYoutube } from "react-icons/fa";
+import { useQuery } from "@apollo/client";
+import { GET_WEEKDAY_BUSINESS_HOURS, client } from "server/actions/Contentful";
 
 const Footer: React.FC = () => {
   const mapSrc =
@@ -33,9 +35,10 @@ const Footer: React.FC = () => {
             HOURS - <span>Admission must be booked online, in advance</span>
           </h1>
           <p>Special Programs Monday & Thursday</p>
-          <p>Friday - 10am-12pm, 1-3pm, 3:30-5:30pm</p>
+          {/*<p>Friday - 10am-12pm, 1-3pm, 3:30-5:30pm</p>
           <p>Saturday - 10am-12pm, 1-3pm, 3:30-5:30pm</p>
-          <p>Sunday - 10am-12pm, 1-3pm</p>
+          <p>Sunday - 10am-12pm, 1-3pm</p> */}
+
           <div className={styles.smContainer}>
             <a
               href="https://www.facebook.com/MuseKnoxville/"

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,12 +1,29 @@
 import styles from "./footer.module.scss";
 import { FaFacebookF, FaInstagram, FaTwitter, FaYoutube } from "react-icons/fa";
 import { useQuery } from "@apollo/client";
-import { GET_WEEKDAY_BUSINESS_HOURS, client } from "server/actions/Contentful";
+import {
+  GET_WEEKDAY_BUSINESS_HOURS,
+  GET_WEEKEND_BUSINESS_HOURS,
+  client,
+} from "server/actions/Contentful";
+import { compressDays } from "utils/helpers";
 
 const Footer: React.FC = () => {
   const mapSrc =
     "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d25758.679140926608!2d-83.94080239265877!3d35.985431235796526!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x885c16f484d1dbdb%3A0x1612d2810873bf5e!2sMuse%20Knoxville!5e0!3m2!1sen!2sus!4v1612997623235!5m2!1sen!2sus";
 
+  const { data: wd, loading: wdl, error: wde } = useQuery(
+    GET_WEEKDAY_BUSINESS_HOURS,
+    {
+      client: client,
+    }
+  );
+  const { data: we, loading: wel, error: wee } = useQuery(
+    GET_WEEKEND_BUSINESS_HOURS,
+    {
+      client: client,
+    }
+  );
   return (
     <footer className={styles.container}>
       <div className={styles.row}>
@@ -35,6 +52,18 @@ const Footer: React.FC = () => {
             HOURS - <span>Admission must be booked online, in advance</span>
           </h1>
           <p>Special Programs Monday & Thursday</p>
+          {wd && !wdl && (
+            <p className={styles.hours}>
+              {compressDays(wd.businessHoursCollection.items[0].daysOpen)}
+              {wd.businessHoursCollection.items[0].hours.join(", ")}
+            </p>
+          )}
+          {we && !wel && (
+            <p className={styles.hours}>
+              {compressDays(we.businessHoursCollection.items[0].daysOpen)}
+              {we.businessHoursCollection.items[0].hours.join(", ")}
+            </p>
+          )}
           {/*<p>Friday - 10am-12pm, 1-3pm, 3:30-5:30pm</p>
           <p>Saturday - 10am-12pm, 1-3pm, 3:30-5:30pm</p>
           <p>Sunday - 10am-12pm, 1-3pm</p> */}

--- a/components/Header/header.module.scss
+++ b/components/Header/header.module.scss
@@ -1,425 +1,445 @@
 $breakpoint: 1100px;
 
-.headerParent{
-    width: auto;
-    height: auto;
-    position: fixed;
-    display: block;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
+.headerParent {
+  width: auto;
+  height: auto;
+  position: fixed;
+  display: block;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
 }
 
 //Upper blue header
-.upperHeader{
-    height: auto;
-    width: auto;
-    position: relative;
-    display: flex;
-    background-color: #78B6D0;
-    color: white;
-    font-size: 16px;
-    @media screen and (min-width: $breakpoint) {
-        padding: 10px 40px;
-    }
-    @media screen and (max-width: $breakpoint) {
-        padding: 10px 20px;
-    }
+.upperHeader {
+  height: auto;
+  width: auto;
+  position: relative;
+  display: flex;
+  background-color: #78b6d0;
+  color: white;
+  font-size: 16px;
+  @media screen and (min-width: $breakpoint) {
+    padding: 10px 40px;
+  }
+  @media screen and (max-width: $breakpoint) {
+    padding: 10px 20px;
+  }
 }
-.upperHeaderLeft{
-    width: auto;
-    height: auto;
-    min-width: 200px;
-    position: relative;
-    display: inline-block;
-    text-align: left;
-    flex: 0;
+.upperHeaderLeft {
+  width: auto;
+  height: auto;
+  min-width: 200px;
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  text-align: left;
+  flex: 0;
+  & > div[data-is-open="true"] {
+    background: green;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+  }
+  & > div[data-is-open="false"] {
+    background: red;
+    width: 10px;
+    height: 10px;
+    margin-right: 10px;
+    border-radius: 50%;
+  }
 }
-.upperHeaderRight{
-    width: auto;
-    height: auto;
-    position: relative;
-    display: inline-block;
-    text-align: right;
-    flex: 1;
+.upperHeaderRight {
+  width: auto;
+  height: auto;
+  position: relative;
+  display: inline-block;
+  text-align: right;
+  flex: 1;
 }
-.upperHeaderRight a{
-    color: white;
-    text-decoration: none;
-    margin-left: 16px;
-    text-align: right;
+.upperHeaderRight a {
+  color: white;
+  text-decoration: none;
+  margin-left: 16px;
+  text-align: right;
 }
-.upperHeaderRight a:nth-child(1){
-    @media screen and (max-width: 560px){
-        display: none;
-    }
+.upperHeaderRight a:nth-child(1) {
+  @media screen and (max-width: 560px) {
+    display: none;
+  }
 }
-.upperHeaderRight a:nth-child(2){
-    @media screen and (max-width: 445px){
-        display: none;
-    }
+.upperHeaderRight a:nth-child(2) {
+  @media screen and (max-width: 445px) {
+    display: none;
+  }
 }
 
 //Lower white header
-.mainHeader{
-    height: 120px;
-    width: auto;
-    position: relative;
-    display: flex;
-    background-color: white;
-    border-bottom: 3px solid #73CDD8;
-    font-size: 16px;
-    @media screen and (min-width: $breakpoint) {
-        padding: 0px 40px;
-    }
-    @media screen and (max-width: $breakpoint) {
-        padding: 0px 20px;
-    }
+.mainHeader {
+  height: 120px;
+  width: auto;
+  position: relative;
+  display: flex;
+  background-color: white;
+  border-bottom: 3px solid #73cdd8;
+  font-size: 16px;
+  @media screen and (min-width: $breakpoint) {
+    padding: 0px 40px;
+  }
+  @media screen and (max-width: $breakpoint) {
+    padding: 0px 20px;
+  }
 }
 //Main header logo container
-.headerLogo{
-    width: auto;
-    height: auto;
-    max-width: 180px;
-    position: relative;
-    display: inline-block;
-    padding: 10px 0px 10px 0px;
-    flex: 0;
+.headerLogo {
+  width: auto;
+  height: auto;
+  max-width: 180px;
+  position: relative;
+  display: inline-block;
+  padding: 10px 0px 10px 0px;
+  flex: 0;
 }
-.headerLogo img{
-    max-height: 100%;
-    width: auto;
-    position: relative;
-    display: block;
+.headerLogo img {
+  max-height: 100%;
+  width: auto;
+  position: relative;
+  display: block;
 }
 //Main header navigation container
-.headerNav{
-    @media screen and (min-width: $breakpoint){
-        width: auto;
-        height: auto;
-        position: relative;
-        display: flex;
-        flex: 1;
-    }
-    @media screen and (max-width: $breakpoint) {
-        width: 0px;
-        height: 100%;
-        display: block;
-        position: fixed;
-        background-color: white;
-        border-left: 5px solid #F99E26;
-        top: 0;
-        bottom: 0;
-        right: 0;
-        margin: -5px;
-        transition: width 0.1s ease;
-        z-index: 2000;
-    }
-}
-.headerNavOpen{
-    @media screen and (min-width: $breakpoint){
-        width: auto;
-        height: auto;
-        position: relative;
-        display: flex;
-        flex: 1;
-    }
-    @media screen and (max-width: $breakpoint) {
-        width: 75vw;
-        height: 100%;
-        display: block;
-        position: fixed;
-        background-color: white;
-        border-left: 5px solid #F99E26;
-        top: 0;
-        bottom: 0;
-        right: 0;
-        transition: width 0.5s ease;
-        z-index: 2000;
-        overflow: auto;
-    }
-}
-.hamburgerButtonParent{
-    @media screen and (min-width: $breakpoint) {
-        display: none;
-    }
-    @media screen and (max-width: $breakpoint) {
-        width: auto;
-        height: auto;
-        position: relative;
-        display: flex;
-        flex: 1; 
-    } 
-}
-.hamburgerButton{
-    position: absolute;
+.headerNav {
+  @media screen and (min-width: $breakpoint) {
+    width: auto;
+    height: auto;
+    position: relative;
+    display: flex;
+    flex: 1;
+  }
+  @media screen and (max-width: $breakpoint) {
+    width: 0px;
+    height: 100%;
+    display: block;
+    position: fixed;
+    background-color: white;
+    border-left: 5px solid #f99e26;
+    top: 0;
+    bottom: 0;
     right: 0;
-    top: 50%;
-    transform: translateY(-50%);
+    margin: -5px;
+    transition: width 0.1s ease;
+    z-index: 2000;
+  }
+}
+.headerNavOpen {
+  @media screen and (min-width: $breakpoint) {
+    width: auto;
+    height: auto;
+    position: relative;
+    display: flex;
+    flex: 1;
+  }
+  @media screen and (max-width: $breakpoint) {
+    width: 75vw;
+    height: 100%;
+    display: block;
+    position: fixed;
+    background-color: white;
+    border-left: 5px solid #f99e26;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    transition: width 0.5s ease;
+    z-index: 2000;
+    overflow: auto;
+  }
+}
+.hamburgerButtonParent {
+  @media screen and (min-width: $breakpoint) {
+    display: none;
+  }
+  @media screen and (max-width: $breakpoint) {
+    width: auto;
+    height: auto;
+    position: relative;
+    display: flex;
+    flex: 1;
+  }
+}
+.hamburgerButton {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  outline: none;
+  background: none;
+  z-index: 2001;
+}
+.hamburgerButtonOpen {
+  position: absolute;
+  right: 0px;
+  transform: translateY(-25px);
+  border: none;
+  outline: none;
+  background: none;
+  z-index: 2001;
+}
+.hamburgerButton:hover,
+.hamburgerButtonOpen:hover {
+  cursor: pointer;
+}
+.hamburgerLine {
+  width: 50px;
+  height: 5px;
+  border-radius: 5px;
+  position: relative;
+  display: block;
+  margin: 7px 0px;
+  background-color: #f99e26;
+  transition: 0.5s ease;
+}
+.hamburgerButton:hover .hamburgerLine:nth-child(1) {
+  transform: translateY(-3px);
+}
+.hamburgerButton:hover .hamburgerLine:nth-child(3) {
+  transform: translateY(3px);
+}
+.hamburgerLineOpen {
+  width: 50px;
+  height: 5px;
+  border-radius: 5px;
+  position: relative;
+  display: block;
+  margin: 7px 0px;
+  background-color: #f99e26;
+  transition: 0.5s ease;
+}
+.hamburgerButtonOpen .hamburgerLineOpen:nth-child(1) {
+  height: 8px;
+  width: 40px;
+  transform: rotate(-45deg) translateY(18px);
+}
+.hamburgerButtonOpen .hamburgerLineOpen:nth-child(2) {
+  transition: 0s ease;
+  opacity: 0;
+}
+.hamburgerButtonOpen .hamburgerLineOpen:nth-child(3) {
+  height: 8px;
+  width: 40px;
+  transform: rotate(45deg) translateY(-18px);
+}
+.mobileHeaderOverlay {
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: none;
+  transition: opacity 0.5s ease;
+  opacity: 0;
+}
+.mobileHeaderOverlayOpen {
+  @media screen and (max-width: $breakpoint) {
+    width: 100%;
+    height: 100%;
+    display: block;
+    position: fixed;
+    background-color: rgba(0, 0, 0, 0.8);
+    opacity: 1;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    transition: opacity 1s ease;
+    z-index: 1900;
     border: none;
     outline: none;
-    background: none;
-    z-index: 2001;
-}
-.hamburgerButtonOpen{
-    position: absolute;
-    right: 0px;
-    transform: translateY(-25px);
-    border: none;
-    outline: none;
-    background: none;
-    z-index: 2001;
-}
-.hamburgerButton:hover, .hamburgerButtonOpen:hover{
-    cursor: pointer;
-}
-.hamburgerLine{
-    width: 50px;
-    height: 5px;
-    border-radius: 5px;
-    position: relative;
-    display: block;
-    margin: 7px 0px;
-    background-color: #F99E26;
-    transition: 0.5s ease;
-}
-.hamburgerButton:hover .hamburgerLine:nth-child(1){
-    transform: translateY(-3px);
-}
-.hamburgerButton:hover .hamburgerLine:nth-child(3){
-    transform: translateY(3px);
-}
-.hamburgerLineOpen{
-    width: 50px;
-    height: 5px;
-    border-radius: 5px;
-    position: relative;
-    display: block;
-    margin: 7px 0px;
-    background-color: #F99E26;
-    transition: 0.5s ease;
-}
-.hamburgerButtonOpen .hamburgerLineOpen:nth-child(1){
-    height: 8px;
-    width: 40px;
-    transform: rotate(-45deg) translateY(18px);
-}
-.hamburgerButtonOpen .hamburgerLineOpen:nth-child(2){
-    transition: 0s ease;
-    opacity: 0;
-}
-.hamburgerButtonOpen .hamburgerLineOpen:nth-child(3){
-    height: 8px;
-    width: 40px;
-    transform: rotate(45deg) translateY(-18px);
-}
-.mobileHeaderOverlay{
-    border: none;
-    padding: 0;
-    margin: 0;
-    background: none;
-    transition: opacity 0.5s ease;
-    opacity: 0;
-}
-.mobileHeaderOverlayOpen{
-    @media screen and (max-width: $breakpoint) {
-        width: 100%;
-        height: 100%;
-        display: block;
-        position: fixed;
-        background-color: rgba(0, 0, 0, 0.8);
-        opacity: 1;
-        top: 0;
-        bottom: 0;
-        right: 0;
-        left: 0;
-        transition: opacity 1s ease;
-        z-index: 1900;
-        border: none;
-        outline: none;
-    }
+  }
 }
 //Navigation container that contains the main navigation links
-.navMain{
-    @media screen and (min-width: $breakpoint){
-        width: auto;
-        height: auto;
-        position: relative;
-        display: flex;
-        text-align: left;
-        flex: 1;
-    }
-    @media screen and (max-width: $breakpoint){
-        height: auto;
-        position: absolute;
-        display: block;
-        top: 220px;
-        right: 0;
-        left: 0;
-    }
+.navMain {
+  @media screen and (min-width: $breakpoint) {
+    width: auto;
+    height: auto;
+    position: relative;
+    display: flex;
+    text-align: left;
+    flex: 1;
+  }
+  @media screen and (max-width: $breakpoint) {
+    height: auto;
+    position: absolute;
+    display: block;
+    top: 220px;
+    right: 0;
+    left: 0;
+  }
 }
-.navMainBtnWrapper{
+.navMainBtnWrapper {
+  position: relative;
+  display: inline-block;
+  @media screen and (max-width: $breakpoint) {
+    width: 100%;
+  }
+}
+.navBtn {
+  //Parent container for navigation buttons
+  @media screen and (min-width: $breakpoint) {
     position: relative;
     display: inline-block;
-    @media screen and (max-width: $breakpoint){
-        width: 100%;
-    }
-}
-.navBtn{ //Parent container for navigation buttons
-    @media screen and (min-width: $breakpoint){
-        position: relative;
-        display: inline-block;
-        padding: 8px 8px;
-        font-size: 18px;
-        top: 50%;
-        transform: translateY(-50%);
-    }
-    @media screen and (max-width: $breakpoint){
-        position: relative;
-        display: block;
-    }
-}
-.navBtn a{ //Buttons that are in the navbar
-    @media screen and (min-width: $breakpoint){
-        color: black;
-        text-decoration: none;
-    }
-    @media screen and (max-width: $breakpoint){
-        max-width: 65%;
-        color: white;
-        text-decoration: none;
-        position: relative;
-        display: block;
-        padding: 10px 20px;
-        font-size: 18px;
-        background-color: #78B6D0;
-        margin-bottom: 10px;
-        border-top-right-radius: 8px;
-        border-bottom-right-radius: 8px;
-        text-align: center;
-    }
-}
-.navBtn .navBtnSub{ //Container for the subnav
-    @media screen and (min-width: $breakpoint){
-        width: auto;
-        position: absolute;
-        color: white;
-        display: none;
-        z-index: 2001;
-        padding-top: 15px;
-    }
-    @media screen and (max-width: $breakpoint){
-        width: auto;
-        position: relative;
-        color: white;
-        display: block;
-        z-index: 2001;
-        padding-bottom: 15px;
-    }
-}
-.navBtn:hover .navBtnSub{
-    display: block;
-}
-.navBtnSub a{ //Links that are inside the subnav
-    width: auto;
-    white-space: nowrap;
-    display: block;
+    padding: 8px 8px;
+    font-size: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+  @media screen and (max-width: $breakpoint) {
     position: relative;
-    padding: 10px 15px;
-    background-color: #F99E26;
-    color: white;
-    transition: 0.5s ease;
-    margin-top: -1px;
-    z-index: 2002;
-    @media screen and (max-width: $breakpoint){
-        max-width: 60%;
-    }
+    display: block;
+  }
 }
-.navBtnSub a:hover{
-    background-color: #FFE090;
+.navBtn a {
+  //Buttons that are in the navbar
+  @media screen and (min-width: $breakpoint) {
     color: black;
-    cursor: pointer;
+    text-decoration: none;
+  }
+  @media screen and (max-width: $breakpoint) {
+    max-width: 65%;
+    color: white;
+    text-decoration: none;
+    position: relative;
+    display: block;
+    padding: 10px 20px;
+    font-size: 18px;
+    background-color: #78b6d0;
+    margin-bottom: 10px;
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+    text-align: center;
+  }
 }
-.navButtonSubTriangle{
-    width: 0px;
-    height: 0px;
+.navBtn .navBtnSub {
+  //Container for the subnav
+  @media screen and (min-width: $breakpoint) {
+    width: auto;
     position: absolute;
-    border-left: 15px solid transparent;
-    border-right: 15px solid transparent;
-    border-bottom: 15px solid #F99E26;
-    top: 0px;
-    left: 0px;
-    z-index: 2000;
-    @media screen and (max-width: $breakpoint){
-        display: none;   
-    }
+    color: white;
+    display: none;
+    z-index: 2001;
+    padding-top: 15px;
+  }
+  @media screen and (max-width: $breakpoint) {
+    width: auto;
+    position: relative;
+    color: white;
+    display: block;
+    z-index: 2001;
+    padding-bottom: 15px;
+  }
+}
+.navBtn:hover .navBtnSub {
+  display: block;
+}
+.navBtnSub a {
+  //Links that are inside the subnav
+  width: auto;
+  white-space: nowrap;
+  display: block;
+  position: relative;
+  padding: 10px 15px;
+  background-color: #f99e26;
+  color: white;
+  transition: 0.5s ease;
+  margin-top: -1px;
+  z-index: 2002;
+  @media screen and (max-width: $breakpoint) {
+    max-width: 60%;
+  }
+}
+.navBtnSub a:hover {
+  background-color: #ffe090;
+  color: black;
+  cursor: pointer;
+}
+.navButtonSubTriangle {
+  width: 0px;
+  height: 0px;
+  position: absolute;
+  border-left: 15px solid transparent;
+  border-right: 15px solid transparent;
+  border-bottom: 15px solid #f99e26;
+  top: 0px;
+  left: 0px;
+  z-index: 2000;
+  @media screen and (max-width: $breakpoint) {
+    display: none;
+  }
 }
 
 //Memberships and Tickets button
-.navCta{
-    @media screen and (min-width: $breakpoint){
-        width: auto;
-        height: auto;
-        position: relative;
-        display: flex;
-        padding-left: 20px;
-        text-align: right;
-        justify-content: right;
-        flex: 0;
-    }
-    @media screen and (max-width: $breakpoint){
-        width: 100%;
-        height: auto;
-        position: absolute;
-        display: block;
-        text-align: right;
-        justify-content: right;
-        top: 140px;
-    }
-}
-.navCtaBtnWrapper{
-    height: auto;
+.navCta {
+  @media screen and (min-width: $breakpoint) {
     width: auto;
+    height: auto;
     position: relative;
+    display: flex;
+    padding-left: 20px;
+    text-align: right;
+    justify-content: right;
+    flex: 0;
+  }
+  @media screen and (max-width: $breakpoint) {
+    width: 100%;
+    height: auto;
+    position: absolute;
     display: block;
     text-align: right;
-    top: 50%;
-    transform: translateY(-50%);
+    justify-content: right;
+    top: 140px;
+  }
 }
-.navCta a{
-    @media screen and (min-width: $breakpoint){
-        position: relative;
-        display: inline;
-        padding: 8px 10px;
-        margin-left: 10px;
-        color: black;
-        text-decoration: none;
-        font-size: 18px;
-        color: white;
-    }
-    @media screen and (max-width: $breakpoint){
-        width: 65%;
-        color: white;
-        text-decoration: none;
-        position: relative;
-        display: block;
-        padding: 10px 20px;
-        font-size: 18px;
-        margin-bottom: 10px;
-        border-top-right-radius: 8px;
-        border-bottom-right-radius: 8px;
-        text-align: center;
-        background-color: #9DC13B;
-    }
+.navCtaBtnWrapper {
+  height: auto;
+  width: auto;
+  position: relative;
+  display: block;
+  text-align: right;
+  top: 50%;
+  transform: translateY(-50%);
 }
-.navCta a:nth-child(1){
-    @media screen and (min-width: $breakpoint){
-        background-color: #9DC13B;
-    }
+.navCta a {
+  @media screen and (min-width: $breakpoint) {
+    position: relative;
+    display: inline;
+    padding: 8px 10px;
+    margin-left: 10px;
+    color: black;
+    text-decoration: none;
+    font-size: 18px;
+    color: white;
+  }
+  @media screen and (max-width: $breakpoint) {
+    width: 65%;
+    color: white;
+    text-decoration: none;
+    position: relative;
+    display: block;
+    padding: 10px 20px;
+    font-size: 18px;
+    margin-bottom: 10px;
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+    text-align: center;
+    background-color: #9dc13b;
+  }
 }
-.navCta a:nth-child(2){
-    @media screen and (min-width: $breakpoint){
-        background-color: #F99E26;
-    }
+.navCta a:nth-child(1) {
+  @media screen and (min-width: $breakpoint) {
+    background-color: #9dc13b;
+  }
+}
+.navCta a:nth-child(2) {
+  @media screen and (min-width: $breakpoint) {
+    background-color: #f99e26;
+  }
 }

--- a/components/Header/header.module.scss
+++ b/components/Header/header.module.scss
@@ -53,8 +53,15 @@ $breakpoint: 1100px;
       display: block;
     }
   }
-  & > div[data-is-open="true"] {
+  & > div[data-is-open="true"][data-closing-soon="false"] {
     background: vars.$muse-green;
+    width: 10px;
+    height: 10px;
+    margin-right: 10px;
+    border-radius: 50%;
+  }
+  & > div[data-is-open="true"][data-closing-soon="true"] {
+    background: vars.$muse-orange;
     width: 10px;
     height: 10px;
     margin-right: 10px;

--- a/components/Header/header.module.scss
+++ b/components/Header/header.module.scss
@@ -47,9 +47,11 @@ $breakpoint: 1100px;
   & > span:hover {
     cursor: pointer;
   }
-  & > span:hover ~ .businessHoursSub,
-  & .businessHoursSub:hover {
-    display: block;
+  @media screen and (min-width: $breakpoint) {
+    & > span:hover ~ .businessHoursSub,
+    & .businessHoursSub:hover {
+      display: block;
+    }
   }
   & > div[data-is-open="true"] {
     background: vars.$muse-green;
@@ -69,11 +71,30 @@ $breakpoint: 1100px;
 .businessHoursSub {
   top: 15px;
   left: 15px;
+  width: 350px;
+  position: absolute;
+  color: white;
+  display: none;
+  z-index: 2002;
+  padding-top: 15px;
   & > p {
-    width: max-content;
-    overflow-wrap: break-word;
-    margin: 0;
+    //Links that are inside the subnav
     word-wrap: break-word;
+    display: block;
+    position: relative;
+    padding: 10px 15px;
+    background-color: #f99e26;
+    color: white;
+    transition: 0.5s ease;
+    margin: 0;
+    z-index: 2003;
+  }
+  &.businessHoursSubActive {
+    display: flex;
+    flex-direction: column;
+    @media screen and (max-width: $breakpoint) {
+      top: 12px;
+    }
   }
 }
 .upperHeaderRight {
@@ -343,8 +364,7 @@ $breakpoint: 1100px;
     text-align: center;
   }
 }
-.navBtn .navBtnSub,
-.businessHoursSub {
+.navBtn .navBtnSub {
   //Container for the subnav
   @media screen and (min-width: $breakpoint) {
     width: auto;
@@ -366,8 +386,7 @@ $breakpoint: 1100px;
 .navBtn:hover .navBtnSub {
   display: block;
 }
-.navBtnSub a,
-.businessHoursSub p {
+.navBtnSub a {
   //Links that are inside the subnav
   width: auto;
   white-space: nowrap;

--- a/components/Header/header.module.scss
+++ b/components/Header/header.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/variables' as vars;
 $breakpoint: 1100px;
 
 .headerParent {
@@ -37,18 +38,42 @@ $breakpoint: 1100px;
   align-items: center;
   text-align: left;
   flex: 0;
+}
+.hours {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: relative;
+  & > span:hover {
+    cursor: pointer;
+  }
+  & > span:hover ~ .businessHoursSub,
+  & .businessHoursSub:hover {
+    display: block;
+  }
   & > div[data-is-open="true"] {
-    background: green;
+    background: vars.$muse-green;
     width: 10px;
     height: 10px;
+    margin-right: 10px;
     border-radius: 50%;
   }
   & > div[data-is-open="false"] {
     background: red;
     width: 10px;
     height: 10px;
-    margin-right: 10px;
     border-radius: 50%;
+    margin-right: 10px;
+  }
+}
+.businessHoursSub {
+  top: 15px;
+  left: 15px;
+  & > p {
+    width: max-content;
+    overflow-wrap: break-word;
+    margin: 0;
+    word-wrap: break-word;
   }
 }
 .upperHeaderRight {
@@ -318,7 +343,8 @@ $breakpoint: 1100px;
     text-align: center;
   }
 }
-.navBtn .navBtnSub {
+.navBtn .navBtnSub,
+.businessHoursSub {
   //Container for the subnav
   @media screen and (min-width: $breakpoint) {
     width: auto;
@@ -340,7 +366,8 @@ $breakpoint: 1100px;
 .navBtn:hover .navBtnSub {
   display: block;
 }
-.navBtnSub a {
+.navBtnSub a,
+.businessHoursSub p {
   //Links that are inside the subnav
   width: auto;
   white-space: nowrap;

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "server/actions/Contentful";
 
 import { useQuery } from "@apollo/client";
+import { BusinessHoursResponse } from "utils/types";
 const Header: React.FC = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [storeOpen, setStoreOpen] = useState(false);
@@ -24,7 +25,7 @@ const Header: React.FC = () => {
     loading: isOpenLoading,
     data: isOpenData,
     error: isOpenError,
-  } = useQuery(query, {
+  } = useQuery<BusinessHoursResponse>(query, {
     client: client,
     pollInterval: 3600000,
   });
@@ -32,7 +33,7 @@ const Header: React.FC = () => {
     loading: otherLoading,
     data: otherData,
     error: otherError,
-  } = useQuery(otherQuery, {
+  } = useQuery<BusinessHoursResponse>(otherQuery, {
     client: client,
     pollInterval: 3600000, //Poll every hour
   });
@@ -66,11 +67,18 @@ const Header: React.FC = () => {
             <div className={styles.hours}>
               <div data-is-open={storeOpen}></div>
               <span
+                role="button"
+                tabIndex={0}
                 onClick={() =>
                   window.innerWidth < 1100
                     ? setBHOpen(!bhOpen)
                     : setBHOpen(!bhOpen)
                 }
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key == "enter") {
+                    setBHOpen(!bhOpen);
+                  }
+                }}
               >
                 {storeOpen ? "We are open!" : "Currently closed."}
               </span>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,17 +1,18 @@
-import React, { useState } from "react";
-import { compressDays } from "utils/helpers";
-import { useEffect } from "react";
+import React, { useState, useEffect } from "react";
+import { compressDays, isOpen, isWeekend } from "utils/helpers";
+
 import styles from "./header.module.scss";
 import {
   client,
   GET_WEEKDAY_BUSINESS_HOURS,
   GET_WEEKEND_BUSINESS_HOURS,
 } from "server/actions/Contentful";
-import { isOpen, isWeekend } from "utils/helpers";
+
 import { useQuery } from "@apollo/client";
 const Header: React.FC = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [storeOpen, setStoreOpen] = useState(false);
+  const [bhOpen, setBHOpen] = useState(false);
   const query = isWeekend()
     ? GET_WEEKEND_BUSINESS_HOURS
     : GET_WEEKDAY_BUSINESS_HOURS;
@@ -37,6 +38,13 @@ const Header: React.FC = () => {
   });
 
   useEffect(() => {
+    if (isOpenData) {
+      if (isOpen(isOpenData.businessHoursCollection.items[0])) {
+        setStoreOpen(true);
+      } else {
+        setStoreOpen(false);
+      }
+    }
     const interval = setInterval(() => {
       if (isOpenData) {
         if (isOpen(isOpenData.businessHoursCollection.items[0])) {
@@ -45,7 +53,7 @@ const Header: React.FC = () => {
           setStoreOpen(false);
         }
       }
-    }, 60000);
+    }, 10000);
 
     return () => clearInterval(interval);
   }, [isOpenData]);
@@ -57,8 +65,20 @@ const Header: React.FC = () => {
           {isOpenData && !isOpenError && !isOpenLoading && (
             <div className={styles.hours}>
               <div data-is-open={storeOpen}></div>
-              <span>{storeOpen ? "We are open!" : "Currently closed."}</span>
-              <div className={styles.businessHoursSub}>
+              <span
+                onClick={() =>
+                  window.innerWidth < 1100
+                    ? setBHOpen(!bhOpen)
+                    : setBHOpen(!bhOpen)
+                }
+              >
+                {storeOpen ? "We are open!" : "Currently closed."}
+              </span>
+              <div
+                className={`${styles.businessHoursSub} ${
+                  bhOpen ? styles.businessHoursSubActive : ""
+                }`}
+              >
                 <div className={styles.navButtonSubTriangle}></div>
                 {otherData && !otherLoading && !otherError && (
                   <p>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -13,18 +13,10 @@ import { BusinessHours } from "utils/types";
 const Header: React.FC = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [storeOpen, setStoreOpen] = useState(false);
-  const query = isWeekend()
-    ? GET_WEEKEND_BUSINESS_HOURS
-    : GET_WEEKDAY_BUSINESS_HOURS;
-  const { loading, data, error } = useQuery(query, {
+  const { loading, data, error } = useQuery(GET_WEEKDAY_BUSINESS_HOURS, {
     client: client,
     pollInterval: 3600000, //Poll every hour to see if the day has changed.
   });
-
-  if (data && !loading) {
-    compressDays(data.businessHoursCollection.items[0].daysOpen);
-  }
-
   return (
     <header className={styles.headerParent}>
       <div className={styles.upperHeader}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from "next/app";
 import "styles/globals.scss";
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return <Component {...pageProps} />;
 }
 export default MyApp;

--- a/pages/api/cart/index.tsx
+++ b/pages/api/cart/index.tsx
@@ -1,8 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
-export default async function handler(
+export default function handler(
   req: NextApiRequest,
   res: NextApiResponse
-): Promise<void> {
+): void {
   if (req.method === "GET") {
     res.status(200).json({
       success: true,

--- a/pages/api/cart/index.tsx
+++ b/pages/api/cart/index.tsx
@@ -1,8 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
-export default function handler(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
-): void {
+): Promise<void> {
   if (req.method === "GET") {
     res.status(200).json({
       success: true,

--- a/server/actions/Contentful/index.ts
+++ b/server/actions/Contentful/index.ts
@@ -1,11 +1,12 @@
 import { ApolloClient, InMemoryCache, gql, HttpLink } from "@apollo/client";
 import fetch from "cross-fetch";
 //* Must be imported before any query can be run.
+const uri = `https://graphql.contentful.com/content/v1/spaces/${
+  process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID as string
+}?access_token=${process.env.NEXT_PUBLIC_CONTENTFUL_DELIVERY_KEY as string}`;
 export const client = new ApolloClient({
   link: new HttpLink({
-    uri: `https://graphql.contentful.com/content/v1/spaces/${
-      process.env.CONTENTFUL_SPACE_ID as string
-    }?access_token=${process.env.CONTENTFUL_DELIVERY_KEY as string}`,
+    uri: uri,
     fetch,
   }),
   cache: new InMemoryCache(),
@@ -13,13 +14,13 @@ export const client = new ApolloClient({
 
 /**
  * @returns all Muse Exhibits from Contentful
- * Doesn't return Exhibit description because it isn't used in the frontend component.
  */
 export const GET_ALL_EXHIBITS = gql`
   query getAllExhibits {
     ourExhibitsCollection {
       items {
         name
+        description
         picture {
           url
         }
@@ -77,7 +78,10 @@ export const GET_ALL_PARTNERS = gql`
     }
   }
 `;
-
+/**
+ *
+ * Retrieves weekend business hours from Contentful.
+ */
 export const GET_WEEKEND_BUSINESS_HOURS = gql`
   query getBusinessHours {
     businessHoursCollection(where: { type_contains: "weekend" }) {

--- a/server/actions/Contentful/index.ts
+++ b/server/actions/Contentful/index.ts
@@ -44,3 +44,30 @@ export const GET_EXHIBIT = gql`
     }
   }
 `;
+/**
+ * Retrieves business hours from Contentful.
+ *
+ */
+export const GET_WEEKDAY_BUSINESS_HOURS = gql`
+  query getBusinessHours {
+    businessHoursCollection(where: { type_contains: "weekday" }) {
+      items {
+        hours
+        daysOpen
+        daysClosed
+      }
+    }
+  }
+`;
+
+export const GET_WEEKEND_BUSINESS_HOURS = gql`
+  query getBusinessHours {
+    businessHoursCollection(where: { type_contains: "weekend" }) {
+      items {
+        hours
+        daysOpen
+        daysClosed
+      }
+    }
+  }
+`;

--- a/server/sum.ts
+++ b/server/sum.ts
@@ -1,3 +1,3 @@
-export const sum = (a: number, b: number) => {
+export const sum = (a: number, b: number): number => {
   return a + b;
 };

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -3,7 +3,7 @@ import { mult } from "server/product";
 //Put the name of your function in the first parameter of describe.
 describe("sum", () => {
   //the it() function will contain your actual test. Use the first parameter of it to describe what your test is testing for.
-  it("Make sure calculations are correct", () => {
+  it("Make sure calculations are correct", (): void => {
     expect(sum(1, 2)).toBe(3);
     expect(sum(2, 5)).toBe(7);
     expect(sum(10, 15)).toBe(25);
@@ -11,7 +11,7 @@ describe("sum", () => {
 });
 
 describe("mult", () => {
-  it("Make sure that mult returns the correct calculations", () => {
+  it("Make sure that mult returns the correct calculations", (): void => {
     expect(mult(2, 2)).toBe(4);
     expect(mult(2, 6)).toBe(12);
     expect(mult(4, 4)).not.toBe(20);

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -11,16 +11,16 @@ export const isOpen = (businessHours: BusinessHours): boolean => {
   const todayHours = today.getHours() + tzOffsetHours - 5;
   let o = false;
   const days = [
+    "Sunday",
     "Monday",
     "Tuesday",
     "Wednesday",
     "Thursday",
     "Friday",
     "Saturday",
-    "Sunday",
   ];
-  if (businessHours.daysOpen.includes(days[today.getDate()])) {
-    businessHours.hours.forEach(hourSet => {
+  if (businessHours.daysOpen?.includes(days[today.getDate()])) {
+    businessHours.hours?.forEach(hourSet => {
       const [open, close] = parseHours(hourSet);
       if (
         todayHours >= open.hour &&
@@ -37,7 +37,11 @@ export const isOpen = (businessHours: BusinessHours): boolean => {
   }
   return o;
 };
-
+/**
+ * Parses the hours from a string of hours.
+ * @param hours The string of hours returned by Contentful. (Ex: 12:00PM-4:00PM)
+ * @returns an array containing the opening and closing hours as separate objects.
+ */
 export const parseHours = (
   hours: string
 ): [
@@ -71,4 +75,78 @@ export const parseHours = (
   };
 
   return [opening, closing];
+};
+
+/**
+ *  Compresses the days open.
+ * @param daysOpen The business days that the Muse is open.
+ * @returns A string expressing the days that the Muse is open.
+ */
+export const compressDays = (daysOpen: string[]): string => {
+  const days = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  enum Days {
+    Sunday = 0,
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday, //6
+  }
+  ("");
+  //Sort the days similar to how they are sorted above.
+  let sorted = daysOpen.slice().sort((a: string, b: string) => {
+    return days.indexOf(a) - days.indexOf(b);
+  });
+  let dayString = `${sorted[0]}`; //String to be concatenated to.
+  //Check for gaps in days open. If the difference in day number between a day and the day after it is greater than 1, that means there's a gap.
+  for (let i = 0; i < sorted.length - 1; i++) {
+    console.log(sorted[i + 1], sorted[i]);
+    if (
+      Days[sorted[i + 1] as keyof typeof Days] -
+        Days[sorted[i] as keyof typeof Days] >
+      1
+    ) {
+      dayString = dayString.concat(`,${sorted[i + 1]}`);
+    } else {
+      if (i == sorted.length - 2 && !dayString.includes(",")) {
+        dayString = dayString.concat(`-${sorted[i + 1]}: `);
+      } else {
+        dayString = dayString.concat(`,${sorted[i + 1]}: `);
+      }
+    }
+  }
+
+  console.log(dayString);
+
+  return dayString;
+};
+
+export const isWeekend = (): boolean => {
+  //! Should Saturday be considered a weekday or weekend?
+  const today = new Date();
+  const days = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  const weekendDays = ["Saturday", "Sunday"];
+  console.log(days[today.getDay()]);
+
+  if (weekendDays.includes(days[today.getDate()])) {
+    return true;
+  }
+  return false;
 };

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -103,7 +103,7 @@ export const compressDays = (daysOpen: string[]): string => {
   }
   ("");
   //Sort the days similar to how they are sorted above.
-  let sorted = daysOpen.slice().sort((a: string, b: string) => {
+  const sorted = daysOpen.slice().sort((a: string, b: string) => {
     return days.indexOf(a) - days.indexOf(b);
   });
   let dayString = `${sorted[0]}`; //String to be concatenated to.
@@ -143,7 +143,7 @@ export const isWeekend = (): boolean => {
     "Friday",
     "Saturday",
   ];
-  const weekendDays = ["Saturday", "Sunday"];
+  const weekendDays = ["Sunday"];
 
   if (weekendDays.includes(days[today.getDate()])) {
     return true;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -110,29 +110,23 @@ export const compressDays = (daysOpen: string[]): string => {
   //Check for gaps in days open. If the difference in day number between a day and the day after it is greater than 1, that means there's a gap.
   if (sorted.length > 1) {
     for (let i = 0; i < sorted.length - 1; i++) {
-      console.log(
-        Days[sorted[i + 1] as keyof typeof Days],
-        Days[sorted[i] as keyof typeof Days]
-      );
       if (
         Days[sorted[i + 1] as keyof typeof Days] -
           Days[sorted[i] as keyof typeof Days] >
         1
       ) {
-        dayString = dayString.concat(`,${sorted[i + 1]}`);
+        dayString = dayString.concat(`, ${sorted[i + 1]}`);
       } else {
         if (i == sorted.length - 2 && !dayString.includes(",")) {
           dayString = dayString.concat(`-${sorted[i + 1]}: `);
         } else if (i == sorted.length - 2 && dayString.includes(",")) {
-          dayString = dayString.concat(`,${sorted[i + 1]}: `);
+          dayString = dayString.concat(`, ${sorted[i + 1]}: `);
         }
       }
     }
   } else {
     dayString = dayString.concat(": ");
   }
-
-  console.log(dayString);
 
   return dayString;
 };
@@ -150,7 +144,6 @@ export const isWeekend = (): boolean => {
     "Saturday",
   ];
   const weekendDays = ["Saturday", "Sunday"];
-  console.log(days[today.getDay()]);
 
   if (weekendDays.includes(days[today.getDate()])) {
     return true;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -109,7 +109,10 @@ export const compressDays = (daysOpen: string[]): string => {
   let dayString = `${sorted[0]}`; //String to be concatenated to.
   //Check for gaps in days open. If the difference in day number between a day and the day after it is greater than 1, that means there's a gap.
   for (let i = 0; i < sorted.length - 1; i++) {
-    console.log(sorted[i + 1], sorted[i]);
+    console.log(
+      Days[sorted[i + 1] as keyof typeof Days],
+      Days[sorted[i] as keyof typeof Days]
+    );
     if (
       Days[sorted[i + 1] as keyof typeof Days] -
         Days[sorted[i] as keyof typeof Days] >
@@ -119,7 +122,7 @@ export const compressDays = (daysOpen: string[]): string => {
     } else {
       if (i == sorted.length - 2 && !dayString.includes(",")) {
         dayString = dayString.concat(`-${sorted[i + 1]}: `);
-      } else {
+      } else if (i == sorted.length - 2 && dayString.includes(",")) {
         dayString = dayString.concat(`,${sorted[i + 1]}: `);
       }
     }

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { parse } from "graphql";
 import { BusinessHours } from "utils/types";
 /**
  * Checks to see if the Muse is open based on the Business hours
@@ -130,7 +131,30 @@ export const compressDays = (daysOpen: string[]): string => {
 
   return dayString;
 };
+/**
+ *
+ * @param hours The array of open/closing hours that the BusinessHours object has.
+ * @returns true if within an hour of closing, false if otherwise.
+ */
+export const closeToClosing = (hours: string[]): boolean => {
+  const today = new Date();
+  const tzOffsetHours = today.getTimezoneOffset() / 60; //Need to convert local time to UTC then to EST.
+  //EST is 5 hours behind UTC, so subtracting 5 from the converted UTC time gets you EST.
+  const todayHours = today.getHours() + tzOffsetHours - 5;
+  let o = false;
+  hours.forEach(hourSet => {
+    const [open, close] = parseHours(hourSet);
+    if (close.hour - todayHours <= 1) {
+      o = true;
+    }
+  });
+  return o;
+};
 
+/**
+ *  Determines if it is the weekend or not so the correct business hours query can be used.
+ * @returns True if it is the weekend, false if not.
+ */
 export const isWeekend = (): boolean => {
   //! Should Saturday be considered a weekday or weekend?
   const today = new Date();

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -108,24 +108,28 @@ export const compressDays = (daysOpen: string[]): string => {
   });
   let dayString = `${sorted[0]}`; //String to be concatenated to.
   //Check for gaps in days open. If the difference in day number between a day and the day after it is greater than 1, that means there's a gap.
-  for (let i = 0; i < sorted.length - 1; i++) {
-    console.log(
-      Days[sorted[i + 1] as keyof typeof Days],
-      Days[sorted[i] as keyof typeof Days]
-    );
-    if (
-      Days[sorted[i + 1] as keyof typeof Days] -
-        Days[sorted[i] as keyof typeof Days] >
-      1
-    ) {
-      dayString = dayString.concat(`,${sorted[i + 1]}`);
-    } else {
-      if (i == sorted.length - 2 && !dayString.includes(",")) {
-        dayString = dayString.concat(`-${sorted[i + 1]}: `);
-      } else if (i == sorted.length - 2 && dayString.includes(",")) {
-        dayString = dayString.concat(`,${sorted[i + 1]}: `);
+  if (sorted.length > 1) {
+    for (let i = 0; i < sorted.length - 1; i++) {
+      console.log(
+        Days[sorted[i + 1] as keyof typeof Days],
+        Days[sorted[i] as keyof typeof Days]
+      );
+      if (
+        Days[sorted[i + 1] as keyof typeof Days] -
+          Days[sorted[i] as keyof typeof Days] >
+        1
+      ) {
+        dayString = dayString.concat(`,${sorted[i + 1]}`);
+      } else {
+        if (i == sorted.length - 2 && !dayString.includes(",")) {
+          dayString = dayString.concat(`-${sorted[i + 1]}: `);
+        } else if (i == sorted.length - 2 && dayString.includes(",")) {
+          dayString = dayString.concat(`,${sorted[i + 1]}: `);
+        }
       }
     }
+  } else {
+    dayString = dayString.concat(": ");
   }
 
   console.log(dayString);

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,0 +1,74 @@
+import { BusinessHours } from "utils/types";
+/**
+ * Checks to see if the Muse is open based on the Business hours
+ * @param businessHours the BusinessHours object returned from Contentful.
+ * @returns true if open, false if not open.
+ */
+export const isOpen = (businessHours: BusinessHours): boolean => {
+  const today = new Date();
+  const tzOffsetHours = today.getTimezoneOffset() / 60; //Need to convert local time to UTC then to EST.
+  //EST is 5 hours behind UTC, so subtracting 5 from the converted UTC time gets you EST.
+  const todayHours = today.getHours() + tzOffsetHours - 5;
+  let o = false;
+  const days = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+  ];
+  if (businessHours.daysOpen.includes(days[today.getDate()])) {
+    businessHours.hours.forEach(hourSet => {
+      const [open, close] = parseHours(hourSet);
+      if (
+        todayHours >= open.hour &&
+        today.getMinutes() >= open.mins &&
+        todayHours <= close.hour
+      ) {
+        if (todayHours == close.hour && today.getMinutes() >= close.mins) {
+          o = false;
+        } else {
+          o = true;
+        }
+      }
+    });
+  }
+  return o;
+};
+
+export const parseHours = (
+  hours: string
+): [
+  opening: { hour: number; mins: number },
+  closing: { hour: number; mins: number }
+] => {
+  //Split the opening and closing hours.
+  const [a, b] = hours.split("-");
+  //Separates the opening and closing hours into hh:mm and AM/PM so they can be parsed.
+  const [openTime, openAMPM] = a.split(/(?=[aApP][mM])/);
+  const [closingTime, closingAMPM] = b.split(/(?=[aApP][mM])/);
+
+  //This splits opening and closing hours into hh and mm
+  const [openingHours, openingMinutes] = openTime.split(":");
+  const [closingHours, closingMinutes] = closingTime.split(":");
+
+  const opening = {
+    //This will be in 24-hour time for easy number comparision later.
+    hour:
+      parseInt(openingHours) +
+      (openAMPM.toLowerCase() == "pm" && parseInt(openingHours) != 12 ? 12 : 0),
+    mins: parseInt(openingMinutes),
+  };
+  const closing = {
+    hour:
+      parseInt(closingHours) +
+      (closingAMPM.toLowerCase() == "pm" && parseInt(closingHours) != 12
+        ? 12
+        : 0),
+    mins: parseInt(closingMinutes),
+  };
+
+  return [opening, closing];
+};

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -24,9 +24,9 @@ export interface Exhibit {
 }
 
 export interface BusinessHours {
-  daysOpen?: string[];
-  daysClosed?: string[];
-  hours?: string[];
+  daysOpen: string[];
+  daysClosed: string[];
+  hours: string[];
 }
 
 export interface Partner {
@@ -34,4 +34,11 @@ export interface Partner {
   name: string;
   image: string;
   url: string;
+}
+
+export interface BusinessHoursResponse {
+  businessHoursCollection: {
+    _typename: string;
+    items: BusinessHours[];
+  };
 }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -24,9 +24,9 @@ export interface Exhibit {
 }
 
 export interface BusinessHours {
-  daysOpen: string[];
-  daysClosed: string[];
-  hours: string[];
+  daysOpen?: string[];
+  daysClosed?: string[];
+  hours?: string[];
 }
 
 export interface Partner {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -20,3 +20,9 @@ export interface Exhibit {
   description: string;
   image: string;
 }
+
+export interface BusinessHours {
+  daysOpen: string[];
+  daysClosed: string[];
+  hours: string[];
+}


### PR DESCRIPTION
### Jira Issue ID(s)
MUSE-73
### Changes
This PR implements the backend and frontend for displaying business hours in the Header and Footer.
NOTE: The contentful environment variables had to be renamed for this to work. You'll have to rename them in your `.env.local` file to include `NEXT_PUBLIC` before the name of them. (Ex: `NEXT_PUBLIC_CONTENTFUL_API_KEY`)
#### Frontend 
* In the Footer, the hours are displayed for all days. 
* In the header, it displays the museum's current open status (it can be either "We are open", "Closing soon" or "Closed.") Mousing over the status on desktop displays all the hours.  Clicking the status on mobile displays them.
* Status checks for updates every minute, but this can be changed later.
#### Backend
* Type introduced to model BusinessHours from Contentful
* Several helper functions to do things like:
  * Determine if it's the weekend or not
  * Parse opening/closing hours out of a string
  * Compress an array of days into a string of days open/closed
  * Determine whether or not the Muse is open or closed

### Screenshots (if needed)
Opening Status
![Screen Shot 2021-03-06 at 1 21 21 PM](https://user-images.githubusercontent.com/25257772/110218582-19e0ab00-7e80-11eb-8770-c28f9784e78c.png)
Desktop
![Screen Shot 2021-03-06 at 1 21 49 PM](https://user-images.githubusercontent.com/25257772/110218823-5f51a800-7e81-11eb-93bc-bf62097a4a94.png)
Mobile
![Screen Shot 2021-03-06 at 1 22 11 PM](https://user-images.githubusercontent.com/25257772/110218588-2107b900-7e80-11eb-9f17-d2b66968dd7e.png)
Footer
![Screen Shot 2021-03-06 at 1 22 18 PM](https://user-images.githubusercontent.com/25257772/110218595-30870200-7e80-11eb-93e9-019b6bf2cb22.png)


Please let me know if I need to change anything.