### PR TITLE
Fixes a styling error on the Contact index page

### DIFF
--- a/components/ContactForm/contactForm.module.scss
+++ b/components/ContactForm/contactForm.module.scss
@@ -5,8 +5,9 @@
     max-width: 500px;
     width: 50%;
     margin: 0 auto;
-    margin-top: 200px;
-    margin-bottom: 50px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+
 }
 .form {
     display: flex;

--- a/pages/contact/index.tsx
+++ b/pages/contact/index.tsx
@@ -1,11 +1,14 @@
 import Layout from "components/Layout";
 import { NextPage } from "next";
 import ContactForm from "components/ContactForm";
-const contact: NextPage = () => {
-  return (
-    <Layout>
-      <ContactForm></ContactForm>;
-    </Layout>
-  );
-};
+const contact: NextPage = () => (
+  <Layout
+    options={{
+      initialView: false,
+      wrapperDisabled: false,
+    }}
+  >
+    <ContactForm></ContactForm>;
+  </Layout>
+);
 export default contact;


### PR DESCRIPTION
### Changes
The ContactForm component was not visible. This PR resolves this issue by making `intialView` and `wrapperDisabled` options `false` for the Layout component on the contact page index.
