### PR TITLE
Adds multi-variation support for items in Square and stock status for all items in Square.

### DIFF
--- a/components/Cart/CartItem/index.tsx
+++ b/components/Cart/CartItem/index.tsx
@@ -66,6 +66,7 @@ const CartItem: React.FC<Props> = ({ item }) => {
             </button>
             {loading ? <div className={styles.spinner}><Spinner/></div> : <></>}
           </div>
+            <h3>{item.selectedVariationFromCart?.name}</h3>
           <h3>${item.variations[0].price}</h3>
           <h4>Quantity</h4>
           <div className={styles.quantity}>

--- a/components/IndividualItem/index.tsx
+++ b/components/IndividualItem/index.tsx
@@ -54,11 +54,15 @@ const IndividualItem: React.FC<Props> = ({ item }) => {
     e.persist();
     //From here: https://stackoverflow.com/questions/29537299/react-how-to-update-state-item1-in-state-using-setstate
     const target = e.target as HTMLInputElement;
+    //Value from the select fields.
     const selectValue = JSON.parse(target.value);
-    console.warn("Option change detected.");
+    //To figure out what optionValue to update, we need to find the option id that matches the one from the select
     const indexToUpdate = optionValues.findIndex(option => option.itemOptionId === selectValue.itemOptionId);
+    //Make a copy of the state so we can update it.
     let optionsCopy = [...optionValues];
+    //Find the option that needs to be updated.
     let optionToUpdate = {...optionsCopy[indexToUpdate]};
+    //Set that option's itemOptionValueId to that of the item from the select.
     optionToUpdate.itemOptionValueId = selectValue.itemOptionValueId;
     optionsCopy[indexToUpdate] = optionToUpdate;
     setOptionValues(optionsCopy);
@@ -105,12 +109,12 @@ const IndividualItem: React.FC<Props> = ({ item }) => {
           {item.variations.length > 1 &&
             (item.options as ItemOption[]) &&
             (item.options as ItemOption[]).map((option: ItemOption) => {
+              const optionValueIndex = optionValues.findIndex(os => os.itemOptionId === option.id); //Used to set the default value in the select.
               return (
                 <>
                   <h3>{option.name}</h3>
-                  <select name={option.name} onBlur={handleOptionInfo}>
+                  <select name={option.name} onChange={handleOptionInfo} defaultValue={JSON.stringify(optionValues[optionValueIndex])}>
                     {option.values?.map(value => {
-                      //This is the default value of the selected variation index.
                       return (
                         <option
                           key={value.id}

--- a/components/IndividualItem/index.tsx
+++ b/components/IndividualItem/index.tsx
@@ -11,8 +11,6 @@ const IndividualItem: React.FC<Props> = ({ item }) => {
   const [success, setSuccess] = React.useState(false);
   const [displayedVariation, setDisplayedVariation] = React.useState(item.variations[0])
   const [optionValues, setOptionValues] = React.useState(item.variations[0].itemOptionValues);
-  const [selectValues, setSelectValues] = React.useState({});
-  console.log(displayedVariation);
   //Handles the quantity state.
   const handleChange = (e: React.SyntheticEvent) => {
     const input = e.target as HTMLInputElement;
@@ -32,7 +30,7 @@ const IndividualItem: React.FC<Props> = ({ item }) => {
   };
   const addToCart = async (e: React.SyntheticEvent): Promise<void> => {
     e.preventDefault();
-    const body = { quantity: quantity, id: item.id };
+    const body = { quantity: quantity, id: item.id, variation: displayedVariation };
 
     const response = await fetch("/api/cart", {
       method: "PUT",
@@ -98,6 +96,15 @@ const IndividualItem: React.FC<Props> = ({ item }) => {
         <h3>{displayedVariation && displayedVariation.name}</h3>
         <div className={styles.content}>
           <h2>${item && displayedVariation.price}</h2>
+          {displayedVariation && displayedVariation.stockStatus === "IN_STOCK" && (
+              <h3>In Stock</h3>
+          )}
+          {displayedVariation && displayedVariation.stockStatus === "LOW_STOCK" && (
+            <h3>Low Stock</h3>
+          )}
+          {displayedVariation && displayedVariation.stockStatus === "OUT_OF_STOCK" && (
+            <h3>Out of Stock</h3>
+          )}
           <div className={styles.quantity}>
             <h4>Quantity</h4>
             <input
@@ -142,9 +149,11 @@ const IndividualItem: React.FC<Props> = ({ item }) => {
               </a>
             </div>
           )}
+          { displayedVariation && displayedVariation.stockStatus != "OUT_OF_STOCK" && (
           <button className={styles.button} onClick={addToCart}>
             Add to Cart
           </button>
+          )}
         </div>
       </div>
     </div>

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -1,4 +1,5 @@
 import Layout from "components/Layout";
+import Head from "next/head";
 import { Item, CartAPIResponse } from "utils/types";
 import useSWR from "swr";
 import CartItem from "components/Cart/CartItem";
@@ -8,7 +9,7 @@ import React, { useState } from "react";
 import { useRouter } from "next/router";
 
 const CartPage: React.FC = () => {
-  const[loading, setLoading] = useState(false); //Controls the spinner next to the checkout button
+  const [loading, setLoading] = useState(false); //Controls the spinner next to the checkout button
   const fetcher = (url: string) => fetch(url).then(r => r.json());
   const { data, error } = useSWR<CartAPIResponse, string>("/api/cart", fetcher);
   const router = useRouter();
@@ -31,9 +32,10 @@ const CartPage: React.FC = () => {
         wrapperDisabled: false,
       }}
     >
-      {!data && !error &&(
-        <CartLoader/>
-      )}
+      <Head>
+        <title>My Cart | Muse Knoxville</title>
+      </Head>
+      {!data && !error && <CartLoader />}
       {data && !error && (
         <h3 className="subtotal">
           Subtotal: $
@@ -47,7 +49,14 @@ const CartPage: React.FC = () => {
             .toFixed(2)}
         </h3>
       )}
-      {data && !error && data.payload.length < 1 && <><p className="cartEmptyText">Your cart is empty.</p><a href="/shop" className="button">Visit Store</a></>}
+      {data && !error && data.payload.length < 1 && (
+        <>
+          <p className="cartEmptyText">Your cart is empty.</p>
+          <a href="/shop" className="button">
+            Visit Store
+          </a>
+        </>
+      )}
       {data &&
         !error &&
         data.payload.length >= 1 &&
@@ -61,14 +70,20 @@ const CartPage: React.FC = () => {
             Proceed to checkout
           </button>
         )}
-        {loading ? <div className="checkoutSpinner"><Spinner/></div> : <></>}
+        {loading ? (
+          <div className="checkoutSpinner">
+            <Spinner />
+          </div>
+        ) : (
+          <></>
+        )}
       </div>
       <style jsx>{`
         .subtotal {
           width: 60%;
           align-self: center;
         }
-        .checkoutParent{
+        .checkoutParent {
           position: relative;
           display: flex;
           justify-content: center;
@@ -89,31 +104,31 @@ const CartPage: React.FC = () => {
           font-size: 1.2rem;
           border: none;
         }
-        .checkoutBtn:hover{
+        .checkoutBtn:hover {
           cursor: pointer;
         }
-        .checkoutSpinner{
+        .checkoutSpinner {
           position: relative;
           display: inline-block;
           padding: 0px 30px;
         }
-        .cartEmptyText{
+        .cartEmptyText {
           font-size: 34px;
           margin: auto;
           margin-bottom: 40px;
         }
-        .button{
+        .button {
           border: none;
           margin: 20px 0px;
-          text-align:center;
+          text-align: center;
           font-size: 24px;
-          font-family: 'Quicksand', 'sans-serif';
+          font-family: "Quicksand", "sans-serif";
           color: white;
           width: 250px;
           padding: 10px 20px;
-          align-self:center;
-          background-color: #9CC03C;
-          cursor:pointer;
+          align-self: center;
+          background-color: #9cc03c;
+          cursor: pointer;
           margin-bottom: 100px;
           text-decoration: none;
         }

--- a/pages/shop/[item].tsx
+++ b/pages/shop/[item].tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Head from "next/head";
 import { Item } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";
 import { getItemByID, getItemsByCategory } from "server/actions/Square/Catalog";
@@ -13,6 +14,9 @@ const IndividualItemPage: NextPage<Props> = ({ item }) => {
   console.log(item);
   return (
     <Layout options={{ initialView: false, wrapperDisabled: false }}>
+      <Head>
+        <title>{item.name} | Muse Knoxville</title>
+      </Head>
       <IndividualItem item={item} />
     </Layout>
   );

--- a/pages/shop/[item].tsx
+++ b/pages/shop/[item].tsx
@@ -10,6 +10,7 @@ interface Props {
 }
 
 const IndividualItemPage: NextPage<Props> = ({ item }) => {
+  console.log(item);
   return (
     <Layout options={{ initialView: false, wrapperDisabled: false }}>
       <IndividualItem item={item} />

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from "next";
+import Head from "next/head";
 import Header from "components/Header";
 import Footer from "components/Footer";
 import ShopCategories from "components/ShopCategories";
@@ -24,6 +25,9 @@ const Shop: NextPage<Props> = ({ items }) => {
   };
   return (
     <main>
+      <Head>
+        <title>Shop | Muse Knoxville</title>
+      </Head>
       <Header />
 
       <div className="banner">
@@ -35,9 +39,9 @@ const Shop: NextPage<Props> = ({ items }) => {
           <FaShoppingCart />
           <span>
             Cart (
-              {data &&
-                !error &&
-                (data as { success: boolean; payload: Item[] }).payload.reduce(
+            {data &&
+              !error &&
+              (data as { success: boolean; payload: Item[] }).payload.reduce(
                 (numItems, item) => {
                   return numItems + item.quantity;
                 },

--- a/server/actions/Square/Catalog.ts
+++ b/server/actions/Square/Catalog.ts
@@ -168,6 +168,7 @@ export const getItemOptions = async (item: CatalogObject): Promise<unknown> => {
         name: option.itemOptionData?.displayName, //This is like "Color, Size, etc."
         values: option.itemOptionData?.values?.map(optionValue => {
           return {
+            id: optionValue.id,
             name: optionValue.itemOptionValueData?.name, //This is like "Green, Blue, Red, etc."
             ordinal: optionValue.itemOptionValueData?.ordinal, //What position that value appears in a list.
           };
@@ -213,6 +214,10 @@ const formatItem = async (squareItem: CatalogObject): Promise<Item> => {
                 ).toFixed(2),
                 stockStatus: await getStockStatus(variation.id),
               };
+              if (variation.itemVariationData?.itemOptionValues != undefined) {
+                formattedVariation.itemOptionValues =
+                  variation.itemVariationData?.itemOptionValues;
+              }
               return formattedVariation;
             })
           )

--- a/server/actions/Square/Catalog.ts
+++ b/server/actions/Square/Catalog.ts
@@ -1,6 +1,7 @@
 import { Client, Environment, CatalogObject } from "square";
 import { getAccessToken } from ".";
-import { Item, ItemVariation } from "utils/types";
+import { Item, ItemOption, ItemVariation } from "utils/types";
+import { getStockStatus } from "./Inventory";
 const client = new Client({
   environment: Environment.Sandbox,
   accessToken: process.env.SQUARE_ACCESS_TOKEN as string,
@@ -57,6 +58,7 @@ export const getItemByID = async (id: string): Promise<Item> => {
     return {} as Item;
   }
 };
+
 /**
  * Batch retrieves an array of items by ID.
  * @param ids - The array of item IDs to be batch retrieved.
@@ -148,6 +150,37 @@ const getImageURL = async (imageId: string): Promise<string> => {
     return "";
   }
 };
+export const getItemOptions = async (item: CatalogObject): Promise<unknown> => {
+  try {
+    const token = await getAccessToken();
+    const newClient = client.withConfiguration({
+      accessToken: token,
+    });
+    const ids = item.itemData?.itemOptions?.map(option => {
+      return option.itemOptionId;
+    });
+    const response = await newClient.catalogApi.batchRetrieveCatalogObjects({
+      objectIds: ids as string[],
+    });
+    return response.result?.objects?.map(option => {
+      return {
+        id: option.id,
+        name: option.itemOptionData?.displayName, //This is like "Color, Size, etc."
+        values: option.itemOptionData?.values?.map(optionValue => {
+          return {
+            name: optionValue.itemOptionValueData?.name, //This is like "Green, Blue, Red, etc."
+            ordinal: optionValue.itemOptionValueData?.ordinal, //What position that value appears in a list.
+          };
+        }),
+      };
+    }) as ItemOption[];
+  } catch (error: unknown) {
+    if (error) {
+      console.log(error as Error);
+    }
+    return {} as ItemOption[];
+  }
+};
 
 /**
  * Format an item from Square for easier use.
@@ -166,20 +199,29 @@ const formatItem = async (squareItem: CatalogObject): Promise<Item> => {
       imageUrl: squareItem.imageId ? await getImageURL(squareItem.imageId) : "",
       quantity: 0,
       variations: squareItem.itemData?.variations
-        ? squareItem.itemData.variations.map(variation => {
-            const formattedVariation: ItemVariation = {
-              id: variation.id,
-              name:
-                variation.itemVariationData?.name || "No variation name found",
-              price: (
-                Number(
-                  variation.itemVariationData?.priceMoney?.amount as bigint
-                ) / 100
-              ).toFixed(2),
-            };
-            return formattedVariation;
-          })
+        ? await Promise.all(
+            squareItem.itemData.variations.map(async variation => {
+              const formattedVariation: ItemVariation = {
+                id: variation.id,
+                name:
+                  variation.itemVariationData?.name ||
+                  "No variation name found",
+                price: (
+                  Number(
+                    variation.itemVariationData?.priceMoney?.amount as bigint
+                  ) / 100
+                ).toFixed(2),
+                stockStatus: await getStockStatus(variation.id),
+              };
+              return formattedVariation;
+            })
+          )
         : ({} as ItemVariation[]),
+      options:
+        squareItem.itemData?.itemOptions &&
+        squareItem.itemData?.itemOptions?.length > 0
+          ? await getItemOptions(squareItem)
+          : {},
     };
     return formattedItem;
   } catch (error: unknown) {

--- a/server/actions/Square/Inventory.ts
+++ b/server/actions/Square/Inventory.ts
@@ -1,0 +1,37 @@
+import { getAccessToken } from ".";
+import { Client, Environment, InventoryCount } from "square";
+const client = new Client({
+  environment:
+    process.env.NODE_ENV === "production"
+      ? Environment.Production
+      : Environment.Sandbox,
+});
+
+export const getStockStatus = async (
+  itemVariationId: string
+): Promise<string> => {
+  //I'm not going to be using Square's stock status to manage the low stock alerts. Instead, if any item has less than 5 stock, then it is "low stock", and any item with a stock of "0" is out of stock.
+  const token = await getAccessToken();
+  const newClient = client.withConfiguration({
+    accessToken: token,
+  });
+
+  const response = await newClient.inventoryApi.retrieveInventoryCount(
+    itemVariationId
+  );
+  const count =
+    response.result.counts &&
+    response.result.counts.length > 0 &&
+    (response?.result?.counts)[0];
+  if (count && parseInt(count.quantity as string) == 0) {
+    return "OUT_OF_STOCK";
+  }
+  if (
+    count &&
+    parseInt(count.quantity as string) > 0 &&
+    parseInt(count.quantity as string) <= 5
+  ) {
+    return "LOW_STOCK";
+  }
+  return "IN_STOCK";
+};

--- a/server/actions/Square/Orders.ts
+++ b/server/actions/Square/Orders.ts
@@ -49,11 +49,11 @@ const createOrderLineObjects = (items: Item[]): OLItem[] => {
   items.forEach(item => {
     const orderLineItem = {
       id: item.id,
-      name: item.name,
+      name: `${item.name} (${item.selectedVariationFromCart?.name})`,
       quantity: item.quantity?.toString(),
       //Amount has to be converted into a BigInt to be compatible with Square's default OrderLineItem type.
       basePriceMoney: {
-        amount: BigInt(parseFloat(item.variations[0]?.price) * 100), //Convert to integer
+        amount: BigInt(parseFloat(item.selectedVariationFromCart?.price as string) * 100), //Convert to integer
         currency: "USD",
       },
     } as OLItem;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,3 +1,5 @@
+import { CatalogItemOptionValueForItemVariation } from "square";
+
 // Implements relevant types
 export interface Item {
   name: string;
@@ -15,6 +17,7 @@ export interface ItemVariation {
   id: string;
   price: string;
   stockStatus: string | Promise<string>;
+  itemOptionValues: CatalogItemOptionValueForItemVariation[];
 }
 
 export interface ItemOption {
@@ -24,6 +27,7 @@ export interface ItemOption {
 }
 
 export interface ItemValues {
+  id?: string;
   name?: string;
   ordinal: number;
 }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -4,6 +4,7 @@ import { CatalogItemOptionValueForItemVariation } from "square";
 export interface Item {
   name: string;
   id: string;
+  selectedVariationFromCart?: ItemVariation;
   description: string;
   imageUrl: string;
   category: string;
@@ -15,9 +16,10 @@ export interface Item {
 export interface ItemVariation {
   name: string;
   id: string;
+  itemId?: string;
   price: string;
   stockStatus: string | Promise<string>;
-  itemOptionValues: CatalogItemOptionValueForItemVariation[];
+  itemOptionValues?: CatalogItemOptionValueForItemVariation[];
 }
 
 export interface ItemOption {
@@ -86,7 +88,7 @@ export interface CartItem {
   id: string;
   quantity: number;
   //Might be needed later for something like shirt size or color, not sure yet.
-  variation?: undefined;
+  variation: ItemVariation;
 }
 
 export interface CartAPIResponse {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,5 +1,4 @@
 // Implements relevant types
-
 export interface Item {
   name: string;
   id: string;
@@ -8,14 +7,26 @@ export interface Item {
   category: string;
   variations: ItemVariation[];
   quantity: number;
+  options: unknown;
 }
 
 export interface ItemVariation {
   name: string;
   id: string;
   price: string;
+  stockStatus: string | Promise<string>;
 }
 
+export interface ItemOption {
+  id: string;
+  name?: string;
+  values?: ItemValues[];
+}
+
+export interface ItemValues {
+  name?: string;
+  ordinal: number;
+}
 export interface Exhibit {
   id: string;
   name: string;


### PR DESCRIPTION
### Jira Issue ID(s)
MUSE-113
### Changes
This PR adds multi variation support for items in Square. If multiple variations exist on an item, they will display in the Individual Item page and users will be able to select them. Each variation has a stock status now, which will determine whether or not the item is available for purchase.  Different variations are also displayed separately in the cart and on checkout. Please let me know if I need to change anything.
### Screenshots (if needed)
Items with only one variation have no dropdowns:
<img width="1428" alt="Screen Shot 2021-07-17 at 5 49 37 PM" src="https://user-images.githubusercontent.com/25257772/126050960-caecc86a-0fd8-46f5-9013-ce44c5fdcc9c.png">
Items with multiple variations will have dropdowns displayed like this:
![Screen Shot 2021-07-17 at 5 51 45 PM](https://user-images.githubusercontent.com/25257772/126050978-62ae9328-59ab-43c3-b3af-a200fb3beda8.png)
Items with different variations display as separate items in the cart:
![Screen Shot 2021-07-17 at 5 52 59 PM](https://user-images.githubusercontent.com/25257772/126051013-a70c50d1-8427-4b73-9d74-9f4c22ef1b0a.png)
Items with different variations display separately on checkout: 
![Screen Shot 2021-07-17 at 5 54 43 PM](https://user-images.githubusercontent.com/25257772/126051033-0ff162fb-813b-4fa8-a2b2-12050a0b816c.png)

